### PR TITLE
[HOTFIX] remove pm2 from yarn test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "scripts": {
     "test": "yarn test-api && yarn test-desktop",
     "test-api": "cd projects/api && yarn test && yarn lint",
-    "test-desktop": "cd projects/desktop && yarn lint && pm2 start ./node_modules/react-scripts/scripts/start.js && wait-on http://localhost:3000",
+    "test-desktop": "cd projects/desktop && yarn lint",
+    "start-desktop": "cd projects/desktop && pm2 start ./node_modules/react-scripts/scripts/start.js && wait-on http://localhost:3000",
     "test-desktop-cypress": "cd projects/desktop && yarn run cypress:run",
     "clean-jobs": "pm2 kill"
   },
   "pre-commit": [
     "test-api",
     "test-desktop",
+    "start-desktop",
     "test-desktop-cypress",
     "clean-jobs"
   ],


### PR DESCRIPTION
The PM2 command should not be executed when doing yarn test.
It should be executed only in the pre-commit hook.